### PR TITLE
Add `"default_area": "tabstrip"`

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -25,6 +25,7 @@
   ],
   "browser_action": {
     "browser_style": true,
+    "default_area": "tabstrip",
     "default_icon": "icons/tabcounter.plain.min.svg",
     "default_popup": "dist/popup.html",
     "default_title": "Tab Counter"


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/browser_action, New in Firefox 54.

Needs updates the descriptions and screenshots on addons.mozilla.org site after release.