### PR TITLE
do not count hidden tabs

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -34,8 +34,8 @@ const updateIcon = async function updateIcon () {
   let currentTab = (await browser.tabs.query({ currentWindow: true, active: true }))[0]
 
   // Get tabs in current window, tabs in all windows, and the number of windows
-  let currentWindow = (await browser.tabs.query({ currentWindow: true })).length.toString()
-  let allTabs = (await browser.tabs.query({})).length.toString()
+  let currentWindow = (await browser.tabs.query({ currentWindow: true, hidden: false })).length.toString()
+  let allTabs = (await browser.tabs.query({ hidden: false })).length.toString()
   let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length.toString()
 
   if (typeof currentTab !== 'undefined') {

--- a/src/popup.js
+++ b/src/popup.js
@@ -19,8 +19,8 @@
  */
 
 async function start () {
-  let currentWindow = (await browser.tabs.query({ currentWindow: true })).length
-  let allTabs = (await browser.tabs.query({})).length
+  let currentWindow = (await browser.tabs.query({ currentWindow: true, hidden: false })).length
+  let allTabs = (await browser.tabs.query({ hidden: false })).length
   let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length.toString()
   document.getElementById('currentWindow').textContent = currentWindow
   document.getElementById('allTabs').textContent = allTabs


### PR DESCRIPTION
I use your add-on on Firefox with [Panorama View](https://addons.mozilla.org/en-US/firefox/addon/panorama-view/) which gathers tabs by groups and hides tabs that aren't in the current group.
The thing is tab-counter counts all tabs even if they are not shown, which is pretty disturbing in my case.
That's why I propose to ignore hidden tabs.