### PR TITLE
Add option to exclude pinned tabs from count

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -6,7 +6,7 @@
     "name": "DaAwesomeP",
     "url": "https://addons.mozilla.org/en-US/firefox/user/DaAwesomeP/"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A button badge that shows the number of tabs open in a window",
   "homepage_url": "https://github.com/DaAwesomeP/tab-counter",
   "manifest_version": 2,

--- a/manifest.opera.json
+++ b/manifest.opera.json
@@ -6,7 +6,7 @@
     "name": "DaAwesomeP",
     "url": "https://daawesomep.github.io/"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A button badge that shows the number of tabs open in a window",
   "homepage_url": "https://github.com/DaAwesomeP/tab-counter",
   "manifest_version": 2,

--- a/src/background.js
+++ b/src/background.js
@@ -41,6 +41,7 @@ const updateIcon = async function updateIcon () {
   let currentWindow = (await browser.tabs.query(currentWindowQuery)).length.toString()
   let allTabs = (await browser.tabs.query(allTabsQuery)).length.toString()
   let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length.toString()
+  let pinnedTabs = (await browser.tabs.query({ pinned: true })).length
 
   if (typeof currentTab !== 'undefined') {
     let text
@@ -57,7 +58,7 @@ const updateIcon = async function updateIcon () {
 
     // Update the tooltip
     browser.browserAction.setTitle({
-      title: `Tab Counter\nTabs in this window:  ${currentWindow}\nTabs in all windows: ${allTabs}\nNumber of windows: ${allWindows}`,
+      title: `Tab Counter\nTabs in this window:  ${currentWindow}\nTabs in all windows: ${allTabs}\nNumber of windows: ${allWindows}\nNumber of pinned tabs: ${pinnedTabs}`,
       tabId: currentTab.id
     })
   }

--- a/src/background.js
+++ b/src/background.js
@@ -34,8 +34,12 @@ const updateIcon = async function updateIcon () {
   let currentTab = (await browser.tabs.query({ currentWindow: true, active: true }))[0]
 
   // Get tabs in current window, tabs in all windows, and the number of windows
-  let currentWindow = (await browser.tabs.query({ currentWindow: true })).length.toString()
-  let allTabs = (await browser.tabs.query({})).length.toString()
+  // Using ternary syntax to avoid issues with lexical scoping
+  let currentWindowQuery = settings.counterExcludePinnedTabs ? { currentWindow: true, pinned: false } : { currentWindow: true }
+  let allTabsQuery = settings.counterExcludePinnedTabs ? { pinned: false } : {}
+
+  let currentWindow = (await browser.tabs.query(currentWindowQuery)).length.toString()
+  let allTabs = (await browser.tabs.query(allTabsQuery)).length.toString()
   let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length.toString()
 
   if (typeof currentTab !== 'undefined') {
@@ -130,6 +134,9 @@ const checkSettings = async function checkSettings (settingsUpdate) {
       settings.badgeTextColorAuto = true
       settings.badgeTextColor = '#000000'
     }
+
+    // Apply pinned tab preference
+    if (!settings.hasOwnProperty('counterExcludePinnedTabs')) settings.counterExcludePinnedTabs = false
   }
   browser.storage.local.set(Object.assign(settings, {
     version: browser.runtime.getManifest().version

--- a/src/options.html
+++ b/src/options.html
@@ -80,6 +80,11 @@
           </td>
           <td><em>A maximum of four characters can be displayed on the badge; this is a browser limitation.</em></td>
         </tr>
+        <tr style="display: block">
+          <td>Exclude Pinned Tabs</td>
+          <td><input type="checkbox" name="counterExcludePinnedTabs" id="counterExcludePinnedTabs" optionType="boolean" /></td>
+          <td><em>When checked, pinned tabs are not counted in the badge icon. They will still be counted in the popup.</em></td>
+        </tr>
         <tr>
       </table>
     </form>

--- a/src/popup.html
+++ b/src/popup.html
@@ -49,6 +49,10 @@
         <td><strong>Number of windows:</strong></td>
         <td><span id="allWindows"></span></td>
       </tr>
+      <tr>
+        <td><strong>Number of pinned tabs:</strong></td>
+        <td><span id="pinnedTabs"></span></td>
+      </tr>
     </table>
     <script type="text/javascript" src="popup.js"></script>
   </body>

--- a/src/popup.js
+++ b/src/popup.js
@@ -19,12 +19,18 @@
  */
 
 async function start () {
-  let currentWindow = (await browser.tabs.query({ currentWindow: true })).length
-  let allTabs = (await browser.tabs.query({})).length
+  let settings = await browser.storage.local.get()
+  let currentWindowQuery = settings.counterExcludePinnedTabs ? { currentWindow: true, pinned: false } : { currentWindow: true }
+  let allTabsQuery = settings.counterExcludePinnedTabs ? { pinned: false } : {}
+
+  let currentWindow = (await browser.tabs.query(currentWindowQuery)).length
+  let allTabs = (await browser.tabs.query(allTabsQuery)).length
   let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length.toString()
+  let pinnedTabs = (await browser.tabs.query({ pinned: true })).length
   document.getElementById('currentWindow').textContent = currentWindow
   document.getElementById('allTabs').textContent = allTabs
   document.getElementById('allWindows').textContent = allWindows
+  document.getElementById('pinnedTabs').textContent = pinnedTabs
 }
 
 if (typeof browser === 'undefined') {


### PR DESCRIPTION
This PR adds an option (disabled by default) to exclude pinned tabs from the counter. It also shows the number of pinned tabs in the popup and bumps the manifest version to v0.4.2. Tested in FF and Opera.