### PR TITLE
badge - use abbreviated number if tab number >=1000

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -45,17 +45,17 @@ const updateIcon = async function updateIcon () {
       if (currentWindow.length > 3)
         text = currentWindow.slice(0, currentWindow.length - 3) + "K"
       else
-        text = currentWindow.toString()
+        text = currentWindow
     }
     else if (counterPreference === 1) { // Badge shows total of all windows
       // abbreviate if thousands of tabs open - assumes there won't be 100k+ tabs open
       if (allTabs.length > 3)
          text = allTabs.slice(0, allTabs.length - 3) + "K"
       else
-        text = allTabs.toString()
+        text = allTabs
     }
     else if (counterPreference === 2) text = `${currentWindow}/${allTabs}` // Badge shows both (Firefox limits to about 3 characters based on width)
-    else if (counterPreference === 4) text = allWindows.toString() // Badge shows total of all windows
+    else if (counterPreference === 4) text = allWindows // Badge shows total of all windows
 
     // Update the badge
     browser.browserAction.setBadgeText({

--- a/src/background.js
+++ b/src/background.js
@@ -34,21 +34,23 @@ const updateIcon = async function updateIcon () {
   let currentTab = (await browser.tabs.query({ currentWindow: true, active: true }))[0]
 
   // Get tabs in current window, tabs in all windows, and the number of windows
-  let currentWindow = (await browser.tabs.query({ currentWindow: true })).length
-  let allTabs = (await browser.tabs.query({})).length
-  let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length
+  let currentWindow = (await browser.tabs.query({ currentWindow: true })).length.toString()
+  let allTabs = (await browser.tabs.query({})).length.toString()
+  let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length.toString()
 
   if (typeof currentTab !== 'undefined') {
     let text
     if (counterPreference === 0) { // Badge shows current window
-      if (currentWindow > 999)
-        text = "1K"
+      // abbreviate if thousands of tabs open - assumes there won't be 100k+ tabs open
+      if (currentWindow.length > 3)
+        text = currentWindow.slice(0, currentWindow.length - 3) + "K"
       else
         text = currentWindow.toString()
     }
     else if (counterPreference === 1) { // Badge shows total of all windows
-      if (allTabs > 999)
-        text = "1K"
+      // abbreviate if thousands of tabs open - assumes there won't be 100k+ tabs open
+      if (allTabs.length > 3)
+         text = allTabs.slice(0, allTabs.length - 3) + "K"
       else
         text = allTabs.toString()
     }

--- a/src/background.js
+++ b/src/background.js
@@ -34,16 +34,26 @@ const updateIcon = async function updateIcon () {
   let currentTab = (await browser.tabs.query({ currentWindow: true, active: true }))[0]
 
   // Get tabs in current window, tabs in all windows, and the number of windows
-  let currentWindow = (await browser.tabs.query({ currentWindow: true })).length.toString()
-  let allTabs = (await browser.tabs.query({})).length.toString()
-  let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length.toString()
+  let currentWindow = (await browser.tabs.query({ currentWindow: true })).length
+  let allTabs = (await browser.tabs.query({})).length
+  let allWindows = (await browser.windows.getAll({ populate: false, windowTypes: ['normal'] })).length
 
   if (typeof currentTab !== 'undefined') {
     let text
-    if (counterPreference === 0) text = currentWindow // Badge shows current window
-    else if (counterPreference === 1) text = allTabs // Badge shows total of all windows
-    else if (counterPreference === 2) text = `${currentWindow}/${allTabs}` // Badge shows both (Firefox limits to about 4 characters based on width)
-    else if (counterPreference === 4) text = allWindows // Badge shows total of all windows
+    if (counterPreference === 0) { // Badge shows current window
+      if (currentWindow > 999)
+        text = "1K"
+      else
+        text = currentWindow.toString()
+    }
+    else if (counterPreference === 1) { // Badge shows total of all windows
+      if (allTabs > 999)
+        text = "1K"
+      else
+        text = allTabs.toString()
+    }
+    else if (counterPreference === 2) text = `${currentWindow}/${allTabs}` // Badge shows both (Firefox limits to about 3 characters based on width)
+    else if (counterPreference === 4) text = allWindows.toString() // Badge shows total of all windows
 
     // Update the badge
     browser.browserAction.setBadgeText({

--- a/src/options.html
+++ b/src/options.html
@@ -78,7 +78,7 @@
               <option value="3">None (disables the counter and hover text; click the icon to see the count)</option>
             </select>
           </td>
-          <td><em>A maximum of four characters can be displayed on the badge; this is a browser limitation.</em></td>
+          <td><em>A maximum of about three characters can be displayed on the badge; this is a browser limitation.</em></td>
         </tr>
         <tr>
       </table>


### PR DESCRIPTION
fix overflow of the tab count badge
fixes https://github.com/DaAwesomeP/tab-counter/issues/47#issuecomment-1771605634

the implementation only handles up to 99K